### PR TITLE
Add support for multiple DNS queries over the same HTTP2 connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Aded
 - Travis CI
+- Support multiple query over the same HTTP2 connection.
 
 ### Changed
 - code refactor between stub and client

--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ sigok.verteiltesysteme.net. 60 IN RRSIG AAAA 5 3 60 20180130030002 2017103103000
 ;ADDITIONAL
 ```
 
-## Caveats
-
-* 1 request per connection only.
-
 ## Development
 
 From within the root of the repository, you can test the proxy, stub and client respectively

--- a/docs/index.md
+++ b/docs/index.md
@@ -108,10 +108,6 @@ sigok.verteiltesysteme.net. 60 IN RRSIG AAAA 5 3 60 20180130030002 2017103103000
 ;ADDITIONAL
 ```
 
-## Caveats
-
-* 1 request per connection only.
-
 ## Development
 
 From within the root of the repository, you can test the proxy, stub and client respectively

--- a/dohproxy/stub.py
+++ b/dohproxy/stub.py
@@ -36,7 +36,8 @@ def main():
     listen = loop.create_datagram_endpoint(
         lambda: protocol.StubServerProtocol(args, logger=logger),
         local_addr=(args.listen_address, args.listen_port))
-    transport, _ = loop.run_until_complete(listen)
+    transport, proto = loop.run_until_complete(listen)
+    loop.run_until_complete(proto.setup_client())
 
     try:
         loop.run_forever()

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -70,8 +70,8 @@ def client_parser_base():
     )
     parser.add_argument(
         '--remote-address',
-        help='Remote address where the DOH proxy is running. '
-             'Default: [%(default)s]',
+        help='Remote address where the DOH proxy is running. If None, '
+        '--domain will be resolved to lookup and IP. Default: [%(default)s]',
     )
     parser.add_argument(
         '--port',


### PR DESCRIPTION
As long as the HTTP2 connection seems to be up, we will send queries over the same connection.

This greatly help in improving latency. As an example, when setting up brand new connection on every queries, a DNS query would take 260ms, when re-using the same connection, it would only take 60ms.