### PR TITLE
Http proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 - Travis CI
 - Support multiple query over the same HTTP2 connection.
+- doh-httpproxy
 
 ### Changed
 - code refactor between stub and client

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Python scripts that supports proxying DNS over HTTPS [draft-ietf-doh-dns-over-ht
 The project comes with 3 commands:
 * doh-client: A tool to perform a DNS query against DOH server.
 * doh-proxy: A service that receives DOH queries and forwards them to a recursive resolver.
+* doh-httpproxy: A Service that runs DOH over HTTP, instead of HTTP2. This can be set behind a reverse proxy.
 * doh-stub: A service that listens for DNS queries and forwards them to a DOH server.
 
 See the CONTRIBUTING file for how to help out.
@@ -16,7 +17,7 @@ You are welcome to use it, but be aware that support is limited and best-effort.
 ## Requirements
 
 * python >= 3.5
-* h2
+* aiohttp
 * aioh2
 * dnspython
 

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+import aiohttp.web
+import argparse
+import asyncio
+import dns.message
+import dns.rcode
+
+from dohproxy import constants, utils
+from dohproxy.protocol import DNSClientProtocol
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--listen-address',
+        default=None,
+        help='The address the proxy should listen on. Default: [%(default)s]'
+    )
+    parser.add_argument(
+        '--port',
+        default=80,
+        type=int,
+        help='Port to listen on. Default: [%(default)s]',
+    )
+    parser.add_argument(
+        '--upstream-resolver',
+        default='::1',
+        help='Upstream recursive resolver to send the query to. '
+             'Default: [%(default)s]',
+    )
+    parser.add_argument(
+        '--uri',
+        default=constants.DOH_URI,
+        help='DNS API URI. Default [%(default)s]',
+    )
+    parser.add_argument(
+        '--level',
+        default='DEBUG',
+        help='log level [%(default)s]',
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Debugging messages...'
+    )
+    return parser.parse_args()
+
+
+async def doh1handler(request):
+    path, params = utils.extract_path_params(request.rel_url.path_qs)
+
+    if request.method == 'GET':
+        if constants.DOH_CONTENT_TYPE_PARAM in params and \
+                len(params[constants.DOH_CONTENT_TYPE_PARAM]):
+            ct = params[constants.DOH_CONTENT_TYPE_PARAM][0]
+        else:
+            return aiohttp.web.Response(status=400, body=b'Missing Body')
+
+        if constants.DOH_BODY_PARAM in params and \
+                len(params[constants.DOH_BODY_PARAM]):
+            body = utils.doh_b64_decode(
+                params[constants.DOH_BODY_PARAM][0])
+        else:
+            return aiohttp.web.Response(status=400, body=b'Missing Body')
+
+    else:
+        body = request.content.read()
+        ct = request.headers.get('content-type')
+
+    if ct != constants.DOH_MEDIA_TYPE:
+        return aiohttp.web.Response(
+            status=415, body=b'Unsupported content type'
+        )
+
+    # Do actual DNS Query
+    dnsq = dns.message.from_wire(body)
+    request.app.logger.info(
+        '[HTTPS] Received: ID {} Question {} Peer {}'.format(
+            dnsq.id,
+            dnsq.question[0],
+            request.transport.get_extra_info('peername'),
+        )
+    )
+    return await request.app.resolve(request, dnsq)
+
+
+class DOHApplication(aiohttp.web.Application):
+
+    def set_upstream_resolver(self, upstream_resolver):
+        self.upstream_resolver = upstream_resolver
+
+    async def resolve(self, request, dnsq):
+        qid = dnsq.id
+        queue = asyncio.Queue(maxsize=1)
+        await self.loop.create_datagram_endpoint(
+                lambda: DNSClientProtocol(dnsq, queue, logger=self.logger),
+                remote_addr=(self.upstream_resolver, 53))
+
+        self.logger.debug("Waiting for DNS response")
+        try:
+            dnsr = await asyncio.wait_for(queue.get(), 10)
+            dnsr.id = qid
+            queue.task_done()
+            return self.on_answer(request, dnsr=dnsr)
+        except asyncio.TimeoutError:
+            self.logger.debug("Request timed out")
+            return self.on_answer(request, dnsq=dnsq)
+
+    def on_answer(self, request, dnsr=None, dnsq=None):
+        headers = {}
+
+        if dnsr is None:
+            dnsr = dns.message.make_response(dnsq)
+            dnsr.set_rcode(dns.rcode.SERVFAIL)
+        elif len(dnsr.answer):
+            ttl = min(r.ttl for r in dnsr.answer)
+            headers['cache-control'] = 'max-age={}'.format(ttl)
+
+        self.logger.info(
+            '[HTTPS] Send: ID {} Question {} Peer {}'.format(
+                dnsr.id,
+                dnsr.question[0],
+                request.transport.get_extra_info('peername')
+            )
+        )
+        body = dnsr.to_wire()
+
+        return aiohttp.web.Response(
+            status=200,
+            body=body,
+            content_type=constants.DOH_MEDIA_TYPE,
+        )
+
+
+def main():
+    args = parse_args()
+
+    logger = utils.configure_logger('doh-httpproxy', args.level)
+    app = DOHApplication(logger=logger)
+    app.set_upstream_resolver(args.upstream_resolver)
+    app.router.add_get(args.uri, doh1handler)
+    aiohttp.web.run_app(app, host=args.listen_address, port=args.port)
+
+
+if __name__ == '__main__':
+    main()

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -13,7 +13,6 @@ import dns.message
 import dns.rcode
 import io
 import ssl
-import urllib.parse
 
 from dohproxy import constants, utils
 from dohproxy.protocol import DNSClientProtocol
@@ -138,12 +137,7 @@ class H2Protocol(asyncio.Protocol):
         method = request_data.headers[':method']
 
         # Handle the actual query
-        path = headers[':path']
-        if u'?' in path:
-            path, query = path.split(u'?', 1)
-        else:
-            query = ''
-        params = urllib.parse.parse_qs(query)
+        path, params = utils.extract_path_params(headers[':path'])
 
         if path != self.uri:
             self.return_404(stream_id)

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -11,7 +11,17 @@ import base64
 import logging
 import urllib.parse
 
+from typing import Dict, List, Tuple
+
 from dohproxy import constants
+
+
+def extract_path_params(url: str) -> Tuple[str, Dict[str, List[str]]]:
+    """ Given a URI, extract the path and the parameters
+    """
+    p = urllib.parse.urlparse(url)
+    params = urllib.parse.parse_qs(p.query)
+    return p.path, params
 
 
 def doh_b64_encode(s: bytes) -> str:

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     ],
     install_requires=[
         'aioh2 >= 0.2.1',
+        'aiohttp',
         'dnspython',
     ],
     tests_require=[
@@ -56,6 +57,7 @@ setup(
         'console_scripts': [
             'doh-client = dohproxy.client:main',
             'doh-proxy = dohproxy.proxy:main',
+            'doh-httpproxy = dohproxy.httpproxy:main',
             'doh-stub = dohproxy.stub:main',
         ],
     },

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -79,3 +79,20 @@ class TestTypoChecker(unittest.TestCase):
         """ Basic test to check that there is no stupid typos.
         """
         utils.configure_logger()
+
+
+def extract_path_params_source():
+    return [
+        ('/foo?a=b&c=d#1234', ('/foo', {'a': ['b'], 'c': ['d']})),
+        ('/foo', ('/foo', {})),
+        ('/foo?#', ('/foo', {})),
+        ('foo', ('foo', {})),
+    ]
+
+
+class TestExtractPathParams(unittest.TestCase):
+    @data_provider(extract_path_params_source)
+    def test_make_url(self, uri, output):
+        path, params = utils.extract_path_params(uri)
+        self.assertEqual(path, output[0])
+        self.assertDictEqual(params, output[1])


### PR DESCRIPTION
Add support for Proxying DOH over HTTP. This will allow putting doh-proxy behind a reverse proxy that may not support HTTP2 with backends.
Current assumption is that the reverse proxy and doh-proxy will run on the same host so I skipped SSL for now.