### PR TITLE
[proxy] handle empty ct parameter

### DIFF
--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -60,8 +60,15 @@ async def doh1handler(request):
         if constants.DOH_CONTENT_TYPE_PARAM in params and \
                 len(params[constants.DOH_CONTENT_TYPE_PARAM]):
             ct = params[constants.DOH_CONTENT_TYPE_PARAM][0]
+            if not ct:
+                # An empty value indicates the default
+                # application/dns-udpwireformat type
+                ct = constants.DOH_MEDIA_TYPE
         else:
-            return aiohttp.web.Response(status=400, body=b'Missing Body')
+            return aiohttp.web.Response(
+                status=400,
+                body=b'Missing Content Type'
+            )
 
         if constants.DOH_BODY_PARAM in params and \
                 len(params[constants.DOH_BODY_PARAM]):

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -147,6 +147,10 @@ class H2Protocol(asyncio.Protocol):
             if constants.DOH_CONTENT_TYPE_PARAM in params and \
                     len(params[constants.DOH_CONTENT_TYPE_PARAM]):
                 ct = params[constants.DOH_CONTENT_TYPE_PARAM][0]
+                if not ct:
+                    # An empty value indicates the default
+                    # application/dns-udpwireformat type
+                    ct = constants.DOH_MEDIA_TYPE
             else:
                 self.return_400(stream_id, body=b'Missing Content Type')
                 return

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -20,7 +20,7 @@ def extract_path_params(url: str) -> Tuple[str, Dict[str, List[str]]]:
     """ Given a URI, extract the path and the parameters
     """
     p = urllib.parse.urlparse(url)
-    params = urllib.parse.parse_qs(p.query)
+    params = urllib.parse.parse_qs(p.query, keep_blank_values=True)
     return p.path, params
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -87,6 +87,9 @@ def extract_path_params_source():
         ('/foo', ('/foo', {})),
         ('/foo?#', ('/foo', {})),
         ('foo', ('foo', {})),
+        # Test that we keep empty values
+        ('/foo?a=b&c', ('/foo', {'a': ['b'], 'c': ['']})),
+        ('/foo?a=b&c=', ('/foo', {'a': ['b'], 'c': ['']})),
     ]
 
 


### PR DESCRIPTION
```The value may either be an explicit media type
   (e.g. ct=application/dns-udpwireformat&body=...) or it may be empty.
   An empty value indicates the default application/dns-udpwireformat
   type (e.g. ct&body=...).```