### PR TITLE
[stub/client] set :scheme to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- set :scheme pseudo-header correctly.  GH #17
 
 ## [0.0.5] - 2018-02-05
 

--- a/dohproxy/protocol.py
+++ b/dohproxy/protocol.py
@@ -131,7 +131,7 @@ class StubServerProtocol:
         headers = [
             (':authority', self.args.domain),
             (':method', self.args.post and 'POST' or 'GET'),
-            (':scheme', 'h2'),
+            (':scheme', 'https'),
         ]
         if self.args.post:
             headers.append(('content-type', constants.DOH_MEDIA_TYPE))


### PR DESCRIPTION
Fixes #17

:scheme should be set to `https`, not `h2`.

Tested with
```
PYTHONPATH=. python3 ./dohproxy/client.py  \
    --domain dns.cloudflare.com \
    --qname www.cloudflare.com \
    --debug --post
```
as well as against dns.google.com implementation, nginx h2 and doh-proxy