### PR TITLE
[proxy] option to specific custome upstream port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- custom upstream port option GH #16
+
 ### Fixed
 - set :scheme pseudo-header correctly.  GH #17
 

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -196,6 +196,12 @@ def proxy_parser_base(*, port: int,
              'Default: [%(default)s]',
     )
     parser.add_argument(
+        '--upstream-port',
+        default=53,
+        help='Upstream recursive resolver port to send the query to. '
+             'Default: [%(default)s]',
+    )
+    parser.add_argument(
         '--uri',
         default=constants.DOH_URI,
         help='DNS API URI. Default [%(default)s]',


### PR DESCRIPTION
Fixes #16

This adds an `--upstream-port` option to the proxies implementation to
support using an alternative port to port 53.
It defaults to 53, so it does not need to be specificed in most common
cases.