### PR TITLE
Add central versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - custom upstream port option GH #16
+- display version with --version
 
 ### Fixed
 - set :scheme pseudo-header correctly.  GH #17

--- a/dohproxy/__init__.py
+++ b/dohproxy/__init__.py
@@ -6,3 +6,5 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
+
+__version__ = '0.0.5'

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -16,7 +16,7 @@ import urllib.parse
 
 from typing import Dict, List, Tuple
 
-from dohproxy import constants, protocol
+from dohproxy import constants, protocol, __version__
 
 
 def extract_path_params(url: str) -> Tuple[str, Dict[str, List[str]]]:
@@ -163,6 +163,11 @@ def client_parser_base():
         action='store_true',
         help=argparse.SUPPRESS,
     )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='%(prog)s {}'.format(__version__)
+    )
     return parser
 
 
@@ -215,6 +220,11 @@ def proxy_parser_base(*, port: int,
         '--debug',
         action='store_true',
         help='Debugging messages...'
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='%(prog)s {}'.format(__version__),
     )
     return parser
 

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,32 @@ from setuptools import setup
 from codecs import open
 from os import path
 
+import re
+
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
+
+def read(*parts):
+    with open(path.join(here, *parts), 'r') as fp:
+        return fp.read()
+
+
+def find_version(*file_paths):
+    version_file = read(*file_paths)
+    version_match = re.search(r'^__version__ = [\'"]([^\'"]*)[\'"]',
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
+
 setup(
     name='doh-proxy',
-    version='0.0.5',
+    version=find_version('dohproxy', '__init__.py'),
     description='A client and proxy implementation of '
                 'https://tools.ietf.org/html/draft-ietf-doh-dns-over-https-02',
     long_description=long_description,


### PR DESCRIPTION
This will allow maintaining setup.py version along with providing a way
for the tools to print their version number using --version.