### PR TITLE
[proxy] handle dns messages with empty question properly

### DIFF
--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -49,9 +49,8 @@ async def doh1handler(request):
 
     dnsq = dns.message.from_wire(body)
     request.app.logger.info(
-        '[HTTPS] Received: ID {} Question {} Peer {}'.format(
-            dnsq.id,
-            dnsq.question[0],
+        '[HTTPS] Received: {} Peer {}'.format(
+            utils.dnsmsg2log(dnsq),
             request.transport.get_extra_info('peername'),
         )
     )
@@ -92,9 +91,8 @@ class DOHApplication(aiohttp.web.Application):
             headers['cache-control'] = 'max-age={}'.format(ttl)
 
         self.logger.info(
-            '[HTTPS] Send: ID {} Question {} Peer {}'.format(
-                dnsr.id,
-                dnsr.question[0],
+            '[HTTPS] Send: {} Peer {}'.format(
+                utils.dnsmsg2log(dnsr),
                 request.transport.get_extra_info('peername')
             )
         )

--- a/dohproxy/protocol.py
+++ b/dohproxy/protocol.py
@@ -44,14 +44,12 @@ class DNSClientProtocol:
     def connection_made(self, transport):
         self.transport = transport
         self.dnsq.id = dns.entropy.random_16()
-        self.logger.info(
-            '[DNS] Send: ID {} {}'.format(self.dnsq.id, self.dnsq.question[0]))
+        self.logger.info('[DNS] Send: {}'.format(utils.dnsmsg2log(self.dnsq)))
         self.transport.sendto(self.dnsq.to_wire())
 
     def datagram_received(self, data, addr):
         dnsr = dns.message.from_wire(data)
-        self.logger.info(
-            '[DNS] Received: ID {} {}'.format(dnsr.id, dnsr.question[0]))
+        self.logger.info('[DNS] Received: {}'.format(utils.dnsmsg2log(dnsr)))
         self.queue.put_nowait(dnsr)
         self.transport.close()
 

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -138,9 +138,8 @@ class H2Protocol(asyncio.Protocol):
             return
 
         self.logger.info(
-            '[HTTPS] Received: ID {} Question {} Peer {}'.format(
-                dnsq.id,
-                dnsq.question[0],
+            '[HTTPS] Received: {} Peer {}'.format(
+                utils.dnsmsg2log(dnsq),
                 self.transport.get_extra_info('peername'),
             )
         )
@@ -158,9 +157,8 @@ class H2Protocol(asyncio.Protocol):
             headers['cache-control'] = 'max-age={}'.format(ttl)
 
         self.logger.info(
-            '[HTTPS] Send: ID {} Question {} Peer {}'.format(
-                dnsr.id,
-                dnsr.question[0],
+            '[HTTPS] Send: {} Peer {}'.format(
+                utils.dnsmsg2log(dnsr),
                 self.transport.get_extra_info('peername')
             )
         )

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -11,12 +11,26 @@ import binascii
 import base64
 import dns.exception
 import dns.message
+import dns.rcode
 import logging
 import urllib.parse
 
 from typing import Dict, List, Tuple
 
 from dohproxy import constants, protocol, __version__
+
+
+def dnsmsg2log(msg: dns.message.Message) -> str:
+    """ Helper function to return a printable excerpt from a dns message object.
+    It handles basic things like potentially empty quesiton section.
+    """
+    question = msg.question[0] if len(msg.question) else '<empty>'
+    return 'ID [{}] RCODE [{}] FLAGS [{}] QUESTION [{}]'.format(
+        msg.id,
+        dns.rcode.to_text(msg.rcode()),
+        dns.flags.to_text(msg.flags),
+        question,
+    )
 
 
 def extract_path_params(url: str) -> Tuple[str, Dict[str, List[str]]]:

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -9,6 +9,7 @@
 
 import binascii
 import dns.message
+import dns.rcode
 import unittest
 
 from dohproxy import constants
@@ -236,3 +237,33 @@ class TestDNSQueryFromBody(unittest.TestCase):
         dnsq = dns.message.Message()
         body = dnsq.to_wire()
         self.assertEqual(utils.dns_query_from_body(body), dnsq)
+
+
+class TestDNSMsg2Log(unittest.TestCase):
+
+    def setUp(self):
+        self._qname = 'example.com'
+        self._qtype = 'A'
+        self._q = dns.message.make_query(self._qname, self._qtype)
+
+    def test_valid_query(self):
+        """
+        test that no exception is thrown with a legitimate query.
+        """
+        utils.dnsmsg2log(self._q)
+
+    def test_valid_response(self):
+        """
+        test that no exception is thrown with a legitimate response.
+        """
+        r = dns.message.make_response(self._q, recursion_available=True)
+        utils.dnsmsg2log(r)
+
+    def test_refused_response_no_question(self):
+        """
+        test that no exception is thrown with a legitimate response.
+        """
+        r = dns.message.make_response(self._q, recursion_available=True)
+        r.set_rcode(dns.rcode.REFUSED)
+        r.question = []
+        utils.dnsmsg2log(r)


### PR DESCRIPTION
When unbound replies with a refused response, question is unset. This
caused the logging to throw an exception.
This change moves the log string generation to a separate function and
handles empty question section.

Fixes #21