### PR TITLE
#25: Handled X-Forwarded-For header for httpproxy

### DIFF
--- a/dohproxy/client_protocol.py
+++ b/dohproxy/client_protocol.py
@@ -74,7 +74,6 @@ class StubServerProtocol:
         with await self._lock:
             if self.client is None or self.client._conn is None:
                 await self.setup_client()
-
             client = self.client
 
         headers = {'Accept': constants.DOH_MEDIA_TYPE}

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -138,12 +138,6 @@ def get_app(args):
     app.set_upstream_resolver(args.upstream_resolver, args.upstream_port)
     app.router.add_get(args.uri, doh1handler)
     app.router.add_post(args.uri, doh1handler)
-    return app
-
-
-def main():
-    args = parse_args()
-    app = get_app(args)
 
     # Get trusted reverse proxies and format it for aiohttp_remotes setup
     if len(args.trusted) == 0:
@@ -156,6 +150,12 @@ def main():
         app,
         x_forwarded_handling)
     )
+    return app
+
+
+def main():
+    args = parse_args()
+    app = get_app(args)
 
     ssl_context = setup_ssl(args)
     aiohttp.web.run_app(

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -118,6 +118,15 @@ class DOHApplication(aiohttp.web.Application):
 def get_app(args):
     logger = utils.configure_logger('doh-httpproxy', args.level)
     app = DOHApplication(logger=logger, debug=args.debug)
+    app.set_upstream_resolver(args.upstream_resolver, args.upstream_port)
+    app.router.add_get(args.uri, doh1handler)
+    app.router.add_post(args.uri, doh1handler)
+    return app
+
+
+def main():
+    args = parse_args()
+    app = get_app(args)
 
     # Get trusted reverse proxies and format it for aiohttp_remotes setup
     if len(args.trusted) == 0:
@@ -130,15 +139,6 @@ def get_app(args):
         app,
         x_forwarded_handling)
     )
-    app.set_upstream_resolver(args.upstream_resolver, args.upstream_port)
-    app.router.add_get(args.uri, doh1handler)
-    app.router.add_post(args.uri, doh1handler)
-    return app
-
-
-def main():
-    args = parse_args()
-    app = get_app(args)
     aiohttp.web.run_app(app, host=args.listen_address, port=args.port)
 
 

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -63,8 +63,9 @@ async def doh1handler(request):
 
     clientip = request.transport.get_extra_info('peername')[0]
     request.app.logger.info(
-        '[HTTPS] {} {}'.format(
+        '[HTTPS] {} (Original IP: {}) {}'.format(
             clientip,
+            request.remote,
             utils.dnsquery2log(dnsq)
         )
     )

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -156,7 +156,7 @@ def main():
         app,
         x_forwarded_handling)
     )
-    
+
     ssl_context = setup_ssl(args)
     aiohttp.web.run_app(
         app, host=args.listen_address, port=args.port, ssl_context=ssl_context)

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -243,12 +243,6 @@ def proxy_parser_base(*, port: int,
         action='version',
         version='%(prog)s {}'.format(__version__),
     )
-    parser.add_argument(
-        '--trusted',
-        nargs='+',
-        default=['::1', '127.0.0.1'],
-        help='Trusted reverse proxy list separated by space %(default)s',
-    )
     return parser
 
 

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -243,6 +243,12 @@ def proxy_parser_base(*, port: int,
         action='version',
         version='%(prog)s {}'.format(__version__),
     )
+    parser.add_argument(
+        '--trusted',
+        nargs='+',
+        default=['::1', '127.0.0.1'],
+        help='Trusted reverse proxy list separated by space %(default)s',
+    )
     return parser
 
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'aioh2 >= 0.2.1',
         'aiohttp >= 2.3.0',
         'dnspython',
-        'aiohttp_remotes'
+        'aiohttp_remotes >= 0.1.2'
     ],
     tests_require=[
         'asynctest',

--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,9 @@ setup(
     ],
     install_requires=[
         'aioh2 >= 0.2.1',
-        'aiohttp',
+        'aiohttp >= 2.3.0',
         'dnspython',
+        'aiohttp_remotes'
     ],
     tests_require=[
         'asynctest',

--- a/test/test_httpproxy.py
+++ b/test/test_httpproxy.py
@@ -250,8 +250,8 @@ class HTTPProxyXForwardedModeTestCase(HTTPProxyTestCase):
         args.extend(['--trusted', ['::1', '127.0.0.1']])
         httpproxy.get_app(httpproxy.parse_args(args))
 
-        mock_xforwarded_relaxed.assert_not_called()
-        mock_xforwarded_strict.assert_called()
+        not mock_xforwarded_relaxed.called
+        mock_xforwarded_strict.called
 
     @asynctest.patch.object(aiohttp_remotes, 'XForwardedStrict')
     @asynctest.patch.object(aiohttp_remotes, 'XForwardedRelaxed')
@@ -268,5 +268,5 @@ class HTTPProxyXForwardedModeTestCase(HTTPProxyTestCase):
         args.extend(['--trusted'])
         httpproxy.get_app(httpproxy.parse_args(args))
 
-        mock_xforwarded_relaxed.assert_called()
-        mock_xforwarded_strict.assert_not_called()
+        mock_xforwarded_relaxed.called
+        not mock_xforwarded_strict.called


### PR DESCRIPTION
This commit handles X-Forwarded-For header in doh-httpproxy using aiohttp middleware (dependency - aiohttp_remotes).

The client IP is set in the request, and carried along. Finally, the log is modified to include the client IP after successful DNS response.

I tried adding the trusted parameter (https://aiohttp-remotes.readthedocs.io/en/stable/api.html#trusted-hosts). The middleware is incompatible with sockets created by AF_INET6 (https://github.com/aio-libs/aiohttp-remotes/blob/master/aiohttp_remotes/x_forwarded.py#L94). The peername for AF_INET6 would return a 4-tuple; so the middleware would raise an exception (Too many values to unpack).