### PR TITLE
Adding httpproxy TLS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ $ sudo doh-httpproxy \
     --listen-address ::1
 ```
 
+`doh-httpproxy` now also supports TLS, that you can enable passing the 
+args `--certfile` and `--keyfile` (just like `doh-proxy`)
 
 ### doh-stub
 

--- a/dohproxy/constants.py
+++ b/dohproxy/constants.py
@@ -12,3 +12,4 @@ DOH_MEDIA_TYPE = 'application/dns-udpwireformat'
 DOH_CONTENT_TYPE_PARAM = 'ct'
 DOH_DNS_PARAM = 'dns'
 DOH_H2_NPN_PROTOCOLS = ['h2']
+DOH_CIPHERS = 'ECDHE+AESGCM'

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -135,7 +135,7 @@ def main():
     args = parse_args()
     app = get_app(args)
 
-    ssl_context =  setup_ssl(args)
+    ssl_context = setup_ssl(args)
 
     aiohttp.web.run_app(
         app, host=args.listen_address, port=args.port, ssl_context=ssl_context)

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -11,7 +11,6 @@ import collections
 import dns.message
 import dns.rcode
 import io
-import ssl
 
 from dohproxy import constants, utils
 from dohproxy.server_protocol import (

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -249,22 +249,10 @@ class H2Protocol(asyncio.Protocol):
             stream_data.data.write(data)
 
 
-def ssl_context(options):
-    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-    ctx.load_cert_chain(options.certfile, keyfile=options.keyfile)
-    ctx.set_alpn_protocols(["h2"])
-    ctx.options |= (
-        ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_COMPRESSION
-    )
-    ctx.set_ciphers("ECDHE+AESGCM")
-
-    return ctx
-
-
 def main():
     args = parse_args()
     logger = utils.configure_logger('doh-proxy', args.level)
-    ssl_ctx = ssl_context(args)
+    ssl_ctx = utils.create_ssl_context(args, http2=True)
     loop = asyncio.get_event_loop()
     for addr in args.listen_address:
         coro = loop.create_server(

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -56,7 +56,7 @@ def create_ssl_context(options: argparse.Namespace,
         ctx.set_alpn_protocols(["h2"])
     ctx.options |= (ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
                     | ssl.OP_NO_COMPRESSION)
-    ctx.set_ciphers("ECDHE+AESGCM")
+    ctx.set_ciphers(constants.DOH_CIPHERS)
 
     return ctx
 

--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -42,6 +42,25 @@ def extract_path_params(url: str) -> Tuple[str, Dict[str, List[str]]]:
     return p.path, params
 
 
+def create_ssl_context(options: argparse.Namespace,
+                       http2: bool = False) -> ssl.SSLContext:
+    """ Create SSL Context for the proxies
+    :param options: where to find the certile and the keyfile
+    :param http2: enable http2 into the context
+    :return: An instance of ssl.SSLContext to be used by the proxies
+    """
+
+    ctx = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+    ctx.load_cert_chain(options.certfile, keyfile=options.keyfile)
+    if http2:
+        ctx.set_alpn_protocols(["h2"])
+    ctx.options |= (ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+                    | ssl.OP_NO_COMPRESSION)
+    ctx.set_ciphers("ECDHE+AESGCM")
+
+    return ctx
+
+
 def create_custom_ssl_context(
         *,
         insecure: bool,
@@ -235,15 +254,16 @@ def proxy_parser_base(*, port: int,
         type=int,
         help='Port to listen on. Default: [%(default)s]',
     )
-    if secure:
-        parser.add_argument(
-            '--certfile',
-            help='SSL cert file.'
-        )
-        parser.add_argument(
-            '--keyfile',
-            help='SSL key file.'
-        )
+    parser.add_argument(
+        '--certfile',
+        help='SSL cert file.',
+        required=secure
+    )
+    parser.add_argument(
+        '--keyfile',
+        help='SSL key file.',
+        required=secure
+    )
     parser.add_argument(
         '--upstream-resolver',
         default='::1',

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -306,6 +306,9 @@ class TestProxySSLContext(unittest.TestCase):
         self.args = argparse.Namespace()
         self.args.certfile = None
         self.args.keyfile = None
+
+        # not all opnssl version may support DOH_CIPHERS, override with the one
+        # supported by the testing platform
         constants.DOH_CIPHERS = ssl._DEFAULT_CIPHERS
 
     def test_proxy_ssl_context(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -306,6 +306,7 @@ class TestProxySSLContext(unittest.TestCase):
         self.args = argparse.Namespace()
         self.args.certfile = None
         self.args.keyfile = None
+        constants.DOH_CIPHERS = ssl._DEFAULT_CIPHERS
 
     def test_proxy_ssl_context(self):
         """ Test a default ssl context, it should have http2 disabled """


### PR DESCRIPTION
The main objective of this PR is to give support for TLS communication between a webserver (e.g. nginx) and the HTTPProxy module from doh-proxy.

Other changes:
For users:
- Now, for `doh-proxy`, the args `--certfile` and `--keyfile` are required;

In code:
- You need to explicitly enable `http2` to create a SSL Context for the proxies;
- Moved and renamed the function `ssl_context` (now `create_ssl_context` inside `utils`) and wrote tests for it;
- Since for `httpproxy` the TLS is optional, there is a new function to do the triage;