### PR TITLE
Remove unnecessary use of sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ unprivileged and on multiple cores.
 
 
 ```shell
-$ sudo doh-httpproxy \
+$ doh-httpproxy \
     --upstream-resolver=::1 \
     --port 8080 \
     --listen-address ::1


### PR DESCRIPTION
Port 8080 can be opened with lower privileges so _sudo_ is not required.