### PR TITLE
fix loggerIgnore issue and add unit tests

### DIFF
--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -76,7 +76,7 @@ class DOHApplication(aiohttp.web.Application):
     async def resolve(self, request, dnsq):
         self.time_stamp = time.time()
         clientip = request.remote
-        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port)
+        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port, logger = self.logger)
         dnsr = await dnsclient.query(dnsq, clientip)
 
         if dnsr is None:

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -76,7 +76,8 @@ class DOHApplication(aiohttp.web.Application):
     async def resolve(self, request, dnsq):
         self.time_stamp = time.time()
         clientip = request.remote
-        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port, logger = self.logger)
+        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port,
+                              logger=self.logger)
         dnsr = await dnsclient.query(dnsq, clientip)
 
         if dnsr is None:

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -193,7 +193,8 @@ class H2Protocol(asyncio.Protocol):
 
     async def resolve(self, dnsq, stream_id):
         clientip = self.transport.get_extra_info('peername')[0]
-        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port, logger = self.logger)
+        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port,
+                              logger=self.logger)
         dnsr = await dnsclient.query(dnsq, clientip)
 
         if dnsr is None:

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -193,7 +193,7 @@ class H2Protocol(asyncio.Protocol):
 
     async def resolve(self, dnsq, stream_id):
         clientip = self.transport.get_extra_info('peername')[0]
-        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port)
+        dnsclient = DNSClient(self.upstream_resolver, self.upstream_port, logger = self.logger)
         dnsr = await dnsclient.query(dnsq, clientip)
 
         if dnsr is None:

--- a/dohproxy/server_protocol.py
+++ b/dohproxy/server_protocol.py
@@ -140,7 +140,7 @@ class DNSClientProtocolUDP(DNSClientProtocol):
         self.transport.close()
 
     def error_received(self, exc):
-        self.logger.debug('Error received: ' + str(exc))
+        self.logger.exception('Error received: ' + str(exc))
 
 
 class DNSClientProtocolTCP(DNSClientProtocol):

--- a/test/test_httpproxy.py
+++ b/test/test_httpproxy.py
@@ -11,12 +11,16 @@ import aiohttp
 import aiohttp_remotes
 import asynctest
 import dns.message
+import logging
 
 from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
 
 from dohproxy import constants
 from dohproxy import httpproxy
 from dohproxy import utils
+from dohproxy import server_protocol
+from dohproxy.server_protocol import DNSClient
+from unittest.mock import MagicMock, patch
 
 
 def echo_dns_q(q):
@@ -273,3 +277,54 @@ class HTTPProxyXForwardedModeTestCase(HTTPProxyTestCase):
 
         mock_xforwarded_relaxed.called
         not mock_xforwarded_strict.called
+
+async def async_magic():
+    pass
+# make MagicMock could be used in 'await' expression
+MagicMock.__await__ = lambda x: async_magic().__await__()
+
+class DNSClientLoggerTestCase(HTTPProxyTestCase):
+    # This class mainly helps verify logger's propagation.
+
+    def setUp(self):
+        super().setUp()
+
+    @asynctest.patch.object(server_protocol.DNSClient, 'query')
+    @patch.object(httpproxy.DOHApplication, 'on_answer')
+    @asynctest.patch('dohproxy.httpproxy.DNSClient')
+    @unittest_run_loop
+    async def test_mock_dnsclient_assigned_logger(self, MockedDNSClient, Mockedon_answer, Mockedquery):
+        """ Test that when MockedDNSClient is created with the doh-httpproxy
+        logger and DEBUG level
+        """
+        Mockedquery.return_value = self.dnsq
+        Mockedon_answer.return_value = aiohttp.web.Response(status=200, body=b'Done')
+        params = utils.build_query_params(self.dnsq.to_wire())
+        request = await self.client.request(
+            'GET', self.endpoint, params=params)
+        request.remote = "127.0.0.1"
+        app = await self.get_application()
+        await app.resolve(request, self.dnsq)
+
+        mylogger = utils.configure_logger(name='doh-httpproxy', level='DEBUG')
+        MockedDNSClient.assert_called_with(app.upstream_resolver, app.upstream_port, logger = mylogger)
+
+    def test_dnsclient_none_logger(self):
+        """ Test that when DNSClient is created without a logger,
+        The default logger and default level 'DEBUG' should be used.
+        """
+        dnsclient = DNSClient("", 80)
+        self.assertEqual(dnsclient.logger.level, 10) #DEBUG's level is 10
+        self.assertEqual(dnsclient.logger.name, 'DNSClient')
+
+    def test_dnsclient_assigned_logger(self):
+        """ Test that when DNSClient is created with a logger,
+        This logger and its corresponding level should be used.
+        """
+        mylogger = logging.getLogger("mylogger")
+        level = 'ERROR'
+        mylogger.setLevel(level)
+
+        dnsclient = DNSClient("", 80, logger = mylogger)
+        self.assertEqual(dnsclient.logger.level, 40) #ERROR's level is 40
+        self.assertEqual(dnsclient.logger.name, 'mylogger')

--- a/test/test_httpproxy.py
+++ b/test/test_httpproxy.py
@@ -278,10 +278,12 @@ class HTTPProxyXForwardedModeTestCase(HTTPProxyTestCase):
         mock_xforwarded_relaxed.called
         not mock_xforwarded_strict.called
 
+
 async def async_magic():
     pass
 # make MagicMock could be used in 'await' expression
 MagicMock.__await__ = lambda x: async_magic().__await__()
+
 
 class DNSClientLoggerTestCase(HTTPProxyTestCase):
     # This class mainly helps verify logger's propagation.
@@ -293,12 +295,15 @@ class DNSClientLoggerTestCase(HTTPProxyTestCase):
     @patch.object(httpproxy.DOHApplication, 'on_answer')
     @asynctest.patch('dohproxy.httpproxy.DNSClient')
     @unittest_run_loop
-    async def test_mock_dnsclient_assigned_logger(self, MockedDNSClient, Mockedon_answer, Mockedquery):
+    async def test_mock_dnsclient_assigned_logger(self, MockedDNSClient,
+                                                  Mockedon_answer,
+                                                  Mockedquery):
         """ Test that when MockedDNSClient is created with the doh-httpproxy
         logger and DEBUG level
         """
         Mockedquery.return_value = self.dnsq
-        Mockedon_answer.return_value = aiohttp.web.Response(status=200, body=b'Done')
+        Mockedon_answer.return_value = aiohttp.web.Response(status=200,
+                                                            body=b'Done')
         params = utils.build_query_params(self.dnsq.to_wire())
         request = await self.client.request(
             'GET', self.endpoint, params=params)
@@ -307,14 +312,16 @@ class DNSClientLoggerTestCase(HTTPProxyTestCase):
         await app.resolve(request, self.dnsq)
 
         mylogger = utils.configure_logger(name='doh-httpproxy', level='DEBUG')
-        MockedDNSClient.assert_called_with(app.upstream_resolver, app.upstream_port, logger = mylogger)
+        MockedDNSClient.assert_called_with(app.upstream_resolver,
+                                           app.upstream_port,
+                                           logger=mylogger)
 
     def test_dnsclient_none_logger(self):
         """ Test that when DNSClient is created without a logger,
         The default logger and default level 'DEBUG' should be used.
         """
         dnsclient = DNSClient("", 80)
-        self.assertEqual(dnsclient.logger.level, 10) #DEBUG's level is 10
+        self.assertEqual(dnsclient.logger.level, 10)  # DEBUG's level is 10
         self.assertEqual(dnsclient.logger.name, 'DNSClient')
 
     def test_dnsclient_assigned_logger(self):
@@ -325,6 +332,6 @@ class DNSClientLoggerTestCase(HTTPProxyTestCase):
         level = 'ERROR'
         mylogger.setLevel(level)
 
-        dnsclient = DNSClient("", 80, logger = mylogger)
-        self.assertEqual(dnsclient.logger.level, 40) #ERROR's level is 40
+        dnsclient = DNSClient("", 80, logger=mylogger)
+        self.assertEqual(dnsclient.logger.level, 40)  # ERROR's level is 40
         self.assertEqual(dnsclient.logger.name, 'mylogger')

--- a/test/test_protocol.py
+++ b/test/test_protocol.py
@@ -128,7 +128,7 @@ class DNSClientTestCase(AioHTTPTestCase):
 
 class DNSClientLoggerTestCase(DNSClientTestCase):
 
-    def setup(self):
+    def setUp(self):
         super().setUp()
 
     @asynctest.patch('dohproxy.server_protocol.DNSClientProtocolTCP')

--- a/test/test_protocol.py
+++ b/test/test_protocol.py
@@ -6,20 +6,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-import asyncio
-import asynctest
 import dns
 import dns.message
 import struct
 import unittest
 
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
-from dohproxy import httpproxy
-from dohproxy import utils
-
 from unittest.mock import patch
-from asyncio.base_events import BaseEventLoop
-from dohproxy.server_protocol import DNSClient, DNSClientProtocolTCP, DNSClientProtocolUDP
+from dohproxy.server_protocol import DNSClientProtocolTCP
 
 
 class TCPTestCase(unittest.TestCase):
@@ -93,69 +86,3 @@ class TCPTestCase(unittest.TestCase):
         self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
         self.client_tcp.data_received(data)
         m_rcv.assert_not_called()
-
-class DNSClientTestCase(AioHTTPTestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.mylogger = utils.configure_logger('mylogger', 'ERROR')
-        self.dnsclient = DNSClient("", 80, logger = self.mylogger)
-        #self.dnsclient = DNSClient("", 80, logger = 'mylogger')
-        self.dnsq = dns.message.make_query(
-            qname='foo.example.com',
-            rdtype='A',
-        )
-
-    def get_args(self):
-            return [
-                '--listen-port',
-                '0',
-                '--level',
-                'DEBUG',
-                '--listen-address',
-                '127.0.0.1',
-                '--uri',
-                '/dns',
-                '--trusted',
-            ]
-
-    async def get_application(self):
-        """
-        Override the get_app method to return your application.
-        """
-        parser, args = httpproxy.parse_args(self.get_args())
-        return httpproxy.get_app(args)
-
-class DNSClientLoggerTestCase(DNSClientTestCase):
-
-    def setUp(self):
-        super().setUp()
-
-    @asynctest.patch('dohproxy.server_protocol.DNSClientProtocolTCP')
-    @asynctest.patch.object(DNSClient, '_try_query')
-    @unittest_run_loop
-    async def test_get_DNSClientProtocolTCP_logger(self, Mocked_try_query, MockedDNSClientProtocolTCP):
-        self.upstream_resolver = None
-        self.upstream_port = None
-        try:
-            await self.dnsclient.query_tcp(self.dnsq, "127.0.0.1", timeout=0)
-        except:
-            pass
-        Mocked_try_query.return_value = self.dnsq
-        expectedlogger = utils.configure_logger(name='mylogger', level='ERROR')
-        self.assertEqual(MockedDNSClientProtocolTCP.call_args[1]['logger'], expectedlogger)
-
-
-    @asynctest.patch('dohproxy.server_protocol.DNSClientProtocolUDP')
-    @asynctest.patch.object(DNSClient, '_try_query')
-    @unittest_run_loop
-    async def test_get_DNSClientProtocolUDP_logger(self, Mocked_try_query, MockedDNSClientProtocolUDP):
-        self.upstream_resolver = None
-        self.upstream_port = None
-        try:
-            await self.dnsclient.query_udp(self.dnsq, "127.0.0.1", timeout=0)
-        except:
-            pass
-        Mocked_try_query.return_value = self.dnsq
-        expectedlogger = utils.configure_logger(name='mylogger', level='ERROR')
-        self.assertEqual(MockedDNSClientProtocolUDP.call_args[1]['logger'], expectedlogger)


### PR DESCRIPTION
Note: this PR is now in pre-review state. Before running a official review, there are a couple of issue are need to be understanding:
 1. how to mock a lambda object 
 2. error for "object MagicMock can't be used in 'await' expression"

This PR tries to fix the previous ignoring inputed logger issue mentioned here:
https://github.com/facebookexperimental/doh-proxy/issues/56

It did the follows:
1.  Finding all occurences of instanciations of DNSClient and pass the logger as part of the context.
2. Testing  to confirm that a mocked DNSClient is called with logger passed to it.
3. Creating DNSClient tests `test/test_protocol.py` where DNSClientProtocol{UDP,TCP} would be mocked and ensuring that DNSClient passes the logger to them.
4. Replacing logger.debug with logger.exception in DNSClientProtocolUDP's error_received().