### PR TITLE
Handle connection timeouts resulting in cancelled futures

### DIFF
--- a/dohproxy/server_protocol.py
+++ b/dohproxy/server_protocol.py
@@ -118,14 +118,19 @@ class DNSClientProtocol(asyncio.Protocol):
 
     def receive_helper(self, dnsr):
         interval = int((time.time() - self.time_stamp) * 1000)
-        self.logger.info(
+        log_message = (
             '[DNS] {} {} {}ms'.format(
                 self.clientip,
                 utils.dnsans2log(dnsr),
                 interval
             )
         )
-        self.fut.set_result(dnsr)
+
+        if not self.fut.cancelled():
+            self.logger.info(log_message)
+            self.fut.set_result(dnsr)
+        else:
+            self.logger.info(log_message + '(CANCELLED)')
 
 
 class DNSClientProtocolUDP(DNSClientProtocol):

--- a/test/test_protocol.py
+++ b/test/test_protocol.py
@@ -6,6 +6,7 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
+import asyncio
 import dns
 import dns.message
 import struct
@@ -27,34 +28,34 @@ class TCPTestCase(unittest.TestCase):
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
     def test_single_valid(self, m_rcv):
         data = struct.pack('!H', len(self.response)) + self.response
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
-        self.client_tcp.data_received(data)
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp.data_received(data)
         m_rcv.assert_called_with(self.dnsr)
 
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
     def test_two_valid(self, m_rcv):
         data = struct.pack('!H', len(self.response)) + self.response
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
-        self.client_tcp.data_received(data + data)
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp.data_received(data + data)
         m_rcv.assert_called_with(self.dnsr)
         self.assertEqual(m_rcv.call_count, 2)
 
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
     def test_partial_valid(self, m_rcv):
         data = struct.pack('!H', len(self.response)) + self.response
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
-        self.client_tcp.data_received(data[0:5])
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp.data_received(data[0:5])
         m_rcv.assert_not_called()
-        self.client_tcp.data_received(data[5:])
+        client_tcp.data_received(data[5:])
         m_rcv.assert_called_with(self.dnsr)
 
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
     def test_len_byte(self, m_rcv):
         data = struct.pack('!H', len(self.response)) + self.response
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
-        self.client_tcp.data_received(data[0:1])
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp.data_received(data[0:1])
         m_rcv.assert_not_called()
-        self.client_tcp.data_received(data[1:])
+        client_tcp.data_received(data[1:])
         m_rcv.assert_called_with(self.dnsr)
 
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
@@ -62,27 +63,42 @@ class TCPTestCase(unittest.TestCase):
         data = struct.pack('!H', len(self.response)) + self.response
         length = len(data)
         data = data * 3
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
-        self.client_tcp.data_received(data[0:length - 3])
-        self.client_tcp.data_received(data[length - 3:length + 1])
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp.data_received(data[0:length - 3])
+        client_tcp.data_received(data[length - 3:length + 1])
         m_rcv.assert_called_with(self.dnsr)
         m_rcv.reset_mock()
-        self.client_tcp.data_received(data[length + 1:2 * length])
+        client_tcp.data_received(data[length + 1:2 * length])
         m_rcv.assert_called_with(self.dnsr)
         m_rcv.reset_mock()
-        self.client_tcp.data_received(data[2 * length:])
+        client_tcp.data_received(data[2 * length:])
         m_rcv.assert_called_with(self.dnsr)
 
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
     def test_single_long(self, m_rcv):
         data = struct.pack('!H', len(self.response) - 3) + self.response
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
         with self.assertRaises(dns.exception.FormError):
-            self.client_tcp.data_received(data)
+            client_tcp.data_received(data)
 
     @patch.object(DNSClientProtocolTCP, 'receive_helper')
     def test_single_short(self, m_rcv):
         data = struct.pack('!H', len(self.response) + 3) + self.response
-        self.client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
-        self.client_tcp.data_received(data)
+        client_tcp = DNSClientProtocolTCP(self.dnsq, [], '10.0.0.0')
+        client_tcp.data_received(data)
         m_rcv.assert_not_called()
+
+    def test_cancelled_future(self):
+        """Ensures that cancelled futures are handled appropriately."""
+        data = struct.pack('!H', len(self.response)) + self.response
+
+        mock_future = unittest.mock.MagicMock(asyncio.Future)
+        client_tcp = DNSClientProtocolTCP(
+            self.dnsq, mock_future, '10.0.0.0')
+        client_tcp.time_stamp = 1000000
+
+        # If the future is cancelled, set_result raises InvalidStateError.
+        mock_future.set_result.side_effect = (
+            asyncio.InvalidStateError('CANCELLED: <Future cancelled>')
+        )
+        client_tcp.data_received(data)


### PR DESCRIPTION
Accommodate cancelled futures resulting from timeouts via explicit checking, and add unit test to validate fix and guard against regressions. #56 