### PR TITLE
Removes support for NPN in doh-proxy

### DIFF
--- a/dohproxy/utils.py
+++ b/dohproxy/utils.py
@@ -128,7 +128,6 @@ def create_custom_ssl_context(
             sslctx.load_verify_locations(cafile=cafile, capath=None)
 
     sslctx.set_alpn_protocols(constants.DOH_H2_NPN_PROTOCOLS)
-    sslctx.set_npn_protocols(constants.DOH_H2_NPN_PROTOCOLS)
 
     return sslctx
 

--- a/test/test_knownservers.py
+++ b/test/test_knownservers.py
@@ -34,8 +34,8 @@ def known_servers():
         ('@jedisct1', 'doh.crypto.sx', '/dns-query'),
         # Timeout
         # ('SecureDNS.eu', 'doh.securedns.eu', '/dns-query'),
-        ('BlahDNS.com JP', 'doh.blahdns.com', '/dns-query'),
-        ('BlahDNS.com DE', 'doh.de.blahdns.com', '/dns-query'),
+        ('BlahDNS.com JP', 'doh-jp.blahdns.com', '/dns-query'),
+        ('BlahDNS.com DE', 'doh-de.blahdns.com', '/dns-query'),
         ('NekomimiRouter.com', 'dns.dns-over-https.com', '/dns-query'),
     ]
 
@@ -64,7 +64,7 @@ class TestKnownServers(asynctest.TestCase):
         self.test_timeout = TEST_TIMEOUT
         if os.getenv('TRAVIS'):
             self.test_timeout = TRAVIS_TIMEOUT
-            for fn in ['set_alpn_protocols', 'set_npn_protocols']:
+            for fn in ['set_alpn_protocols']:
                 patcher = unittest.mock.patch('ssl.SSLContext.{0}'.format(fn))
                 patcher.start()
                 self.addCleanup(patcher.stop)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -437,7 +437,7 @@ class TestSSLContext(unittest.TestCase):
 
         # ALPN requires >=openssl-1.0.2
         # NPN requires >=openssl-1.0.1
-        for fn in ['set_alpn_protocols', 'set_npn_protocols']:
+        for fn in ['set_alpn_protocols']:
             patcher = unittest.mock.patch('ssl.SSLContext.{0}'.format(fn))
             patcher.start()
             self.addCleanup(patcher.stop)


### PR DESCRIPTION
* Removes references to `set_npn_protocols` function
* Fixes domain names for BlahDNS queries in test/test_knownservers.py

Output of `python3 setup.py test`:

```
$ python3 setup.py test
running pytest
Searching for unittest-data-provider
Best match: unittest-data-provider 1.0.1
Processing unittest_data_provider-1.0.1-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/unittest_data_provider-1.0.1-py3.6.egg
Searching for pytest-cov
Best match: pytest-cov 2.7.1
Processing pytest_cov-2.7.1-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/pytest_cov-2.7.1-py3.6.egg
Searching for pytest-aiohttp
Best match: pytest-aiohttp 0.3.0
Processing pytest_aiohttp-0.3.0-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/pytest_aiohttp-0.3.0-py3.6.egg
Searching for pytest
Best match: pytest 4.4.2
Processing pytest-4.4.2-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/pytest-4.4.2-py3.6.egg
Searching for asynctest
Best match: asynctest 0.12.4
Processing asynctest-0.12.4-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/asynctest-0.12.4-py3.6.egg
Searching for coverage>=4.4
Best match: coverage 5.0a5
Processing coverage-5.0a5-py3.6-macosx-10.12-x86_64.egg

Using /Users/jakalyan/doh-proxy/.eggs/coverage-5.0a5-py3.6-macosx-10.12-x86_64.egg
Searching for six>=1.10.0
Best match: six 1.12.0
Processing six-1.12.0-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/six-1.12.0-py3.6.egg
Searching for py>=1.5.0
Best match: py 1.8.0
Processing py-1.8.0-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/py-1.8.0-py3.6.egg
Searching for pluggy>=0.11
Best match: pluggy 0.11.0
Processing pluggy-0.11.0-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/pluggy-0.11.0-py3.6.egg
Searching for more-itertools>=4.0.0
Best match: more-itertools 7.0.0
Processing more_itertools-7.0.0-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/more_itertools-7.0.0-py3.6.egg
Searching for atomicwrites>=1.0
Best match: atomicwrites 1.3.0
Processing atomicwrites-1.3.0-py3.6.egg

Using /Users/jakalyan/doh-proxy/.eggs/atomicwrites-1.3.0-py3.6.egg
running egg_info
writing doh_proxy.egg-info/PKG-INFO
writing dependency_links to doh_proxy.egg-info/dependency_links.txt
writing entry points to doh_proxy.egg-info/entry_points.txt
writing requirements to doh_proxy.egg-info/requires.txt
writing top-level names to doh_proxy.egg-info/top_level.txt
reading manifest file 'doh_proxy.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'doh_proxy.egg-info/SOURCES.txt'
running build_ext
=========================================================================================================================================================================== test session starts ============================================================================================================================================================================
platform darwin -- Python 3.6.2+, pytest-4.4.2, py-1.8.0, pluggy-0.11.0 -- /Users/jakalyan/doh-proxy/venv/bin/python3
cachedir: .pytest_cache
rootdir: /Users/jakalyan/doh-proxy, inifile: setup.cfg
plugins: aiohttp-0.3.0, cov-2.7.1
collected 56 items

test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_bad_content_type PASSED                                                                                                                                                                                                                                                                               [  1%]
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_bad_dns_request PASSED                                                                                                                                                                                                                                                                                [  3%]
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_empty_body PASSED                                                                                                                                                                                                                                                                                     [  5%]
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_no_content_type PASSED                                                                                                                                                                                                                                                                                [  7%]
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_valid_request PASSED                                                                                                                                                                                                                                                                                          [  8%]
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_bad_content_type PASSED                                                                                                                                                                                                                                                                             [ 10%]
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_bad_dns_request PASSED                                                                                                                                                                                                                                                                              [ 12%]
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_empty_body PASSED                                                                                                                                                                                                                                                                                   [ 14%]
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_no_content_type PASSED                                                                                                                                                                                                                                                                              [ 16%]
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_valid_request PASSED                                                                                                                                                                                                                                                                                        [ 17%]
test/test_httpproxy.py::HTTPProxyXForwardedModeTestCase::test_xforwarded_mode_with_trusted_hosts PASSED                                                                                                                                                                                                                                                              [ 19%]
test/test_httpproxy.py::HTTPProxyXForwardedModeTestCase::test_xforwarded_mode_without_trusted_hosts PASSED                                                                                                                                                                                                                                                           [ 21%]
test/test_httpproxy.py::DNSClientLoggerTestCase::test_dnsclient_assigned_logger PASSED                                                                                                                                                                                                                                                                               [ 23%]
test/test_httpproxy.py::DNSClientLoggerTestCase::test_dnsclient_none_logger PASSED                                                                                                                                                                                                                                                                                   [ 25%]
test/test_httpproxy.py::DNSClientLoggerTestCase::test_mock_dnsclient_assigned_logger PASSED                                                                                                                                                                                                                                                                          [ 26%]
test/test_knownservers.py::TestKnownServers::test_servers_get SKIPPED                                                                                                                                                                                                                                                                                                [ 28%]
test/test_knownservers.py::TestKnownServers::test_servers_post PASSED                                                                                                                                                                                                                                                                                                [ 30%]
test/test_protocol.py::TCPTestCase::test_cancelled_future PASSED                                                                                                                                                                                                                                                                                                     [ 32%]
test/test_protocol.py::TCPTestCase::test_complex PASSED                                                                                                                                                                                                                                                                                                              [ 33%]
test/test_protocol.py::TCPTestCase::test_len_byte PASSED                                                                                                                                                                                                                                                                                                             [ 35%]
test/test_protocol.py::TCPTestCase::test_partial_valid PASSED                                                                                                                                                                                                                                                                                                        [ 37%]
test/test_protocol.py::TCPTestCase::test_single_long PASSED                                                                                                                                                                                                                                                                                                          [ 39%]
test/test_protocol.py::TCPTestCase::test_single_short PASSED                                                                                                                                                                                                                                                                                                         [ 41%]
test/test_protocol.py::TCPTestCase::test_single_valid PASSED                                                                                                                                                                                                                                                                                                         [ 42%]
test/test_protocol.py::TCPTestCase::test_two_valid PASSED                                                                                                                                                                                                                                                                                                            [ 44%]
test/test_utils.py::TestDOHB64::test_b64_decode PASSED                                                                                                                                                                                                                                                                                                               [ 46%]
test/test_utils.py::TestDOHB64::test_b64_decode_invalid PASSED                                                                                                                                                                                                                                                                                                       [ 48%]
test/test_utils.py::TestDOHB64::test_b64_encode PASSED                                                                                                                                                                                                                                                                                                               [ 50%]
test/test_utils.py::TestMakeURL::test_make_url PASSED                                                                                                                                                                                                                                                                                                                [ 51%]
test/test_utils.py::TestBuildQueryParams::test_body_b64encoded PASSED                                                                                                                                                                                                                                                                                                [ 53%]
test/test_utils.py::TestBuildQueryParams::test_has_right_keys PASSED                                                                                                                                                                                                                                                                                                 [ 55%]
test/test_utils.py::TestBuildQueryParams::test_query_accepts_bytes PASSED                                                                                                                                                                                                                                                                                            [ 57%]
test/test_utils.py::TestBuildQueryParams::test_query_must_be_bytes PASSED                                                                                                                                                                                                                                                                                            [ 58%]
test/test_utils.py::TestTypoChecker::test_client_base_parser PASSED                                                                                                                                                                                                                                                                                                  [ 60%]
test/test_utils.py::TestTypoChecker::test_configure_logger PASSED                                                                                                                                                                                                                                                                                                    [ 62%]
test/test_utils.py::TestTypoChecker::test_configure_logger_unknown_level PASSED                                                                                                                                                                                                                                                                                      [ 64%]
test/test_utils.py::TestTypoChecker::test_proxy_base_default_secure_require_certs PASSED                                                                                                                                                                                                                                                                             [ 66%]
test/test_utils.py::TestTypoChecker::test_proxy_base_non_secure_no_certfile PASSED                                                                                                                                                                                                                                                                                   [ 67%]
test/test_utils.py::TestTypoChecker::test_proxy_base_parser_noargs PASSED                                                                                                                                                                                                                                                                                            [ 69%]
test/test_utils.py::TestExtractPathParams::test_extract_path_params PASSED                                                                                                                                                                                                                                                                                           [ 71%]
test/test_utils.py::TestExtractCtBody::test_extract_ct_body_invalid PASSED                                                                                                                                                                                                                                                                                           [ 73%]
test/test_utils.py::TestExtractCtBody::test_extract_ct_body_valid PASSED                                                                                                                                                                                                                                                                                             [ 75%]
test/test_utils.py::TestDNSQueryFromBody::test_invalid_message_no_debug PASSED                                                                                                                                                                                                                                                                                       [ 76%]
test/test_utils.py::TestDNSQueryFromBody::test_invalid_message_with_debug PASSED                                                                                                                                                                                                                                                                                     [ 78%]
test/test_utils.py::TestDNSQueryFromBody::test_valid_message PASSED                                                                                                                                                                                                                                                                                                  [ 80%]
test/test_utils.py::TestDNSQuery2Log::test_refused_response_no_question PASSED                                                                                                                                                                                                                                                                                       [ 82%]
test/test_utils.py::TestDNSQuery2Log::test_valid_query PASSED                                                                                                                                                                                                                                                                                                        [ 83%]
test/test_utils.py::TestDNSQuery2Log::test_valid_response PASSED                                                                                                                                                                                                                                                                                                     [ 85%]
test/test_utils.py::TestDNSAns2Log::test_refused_response_no_question PASSED                                                                                                                                                                                                                                                                                         [ 87%]
test/test_utils.py::TestDNSAns2Log::test_valid_query PASSED                                                                                                                                                                                                                                                                                                          [ 89%]
test/test_utils.py::TestDNSAns2Log::test_valid_response PASSED                                                                                                                                                                                                                                                                                                       [ 91%]
test/test_utils.py::TestProxySSLContext::test_proxy_ssl_context PASSED                                                                                                                                                                                                                                                                                               [ 92%]
test/test_utils.py::TestProxySSLContext::test_proxy_ssl_context_http2_enabled PASSED                                                                                                                                                                                                                                                                                 [ 94%]
test/test_utils.py::TestSSLContext::test_cafile PASSED                                                                                                                                                                                                                                                                                                               [ 96%]
test/test_utils.py::TestSSLContext::test_insecure_context PASSED                                                                                                                                                                                                                                                                                                     [ 98%]
test/test_utils.py::TestSSLContext::test_secure_context PASSED                                                                                                                                                                                                                                                                                                       [100%]

============================================================================================================================================================================= warnings summary =============================================================================================================================================================================
Removes support for NPN in doh-proxy
venv/lib/python3.6/abc.py:133
  /Users/jakalyan/doh-proxy/venv/bin/../lib/python3.6/abc.py:133: DeprecationWarning: Inheritance class DOHApplication from web.Application is discouraged
    cls = super().__new__(mcls, name, bases, namespace, **kwargs)

test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_bad_content_type
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_bad_dns_request
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_empty_body
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_no_content_type
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_valid_request
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_bad_content_type
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_bad_dns_request
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_empty_body
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_no_content_type
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_valid_request
test/test_httpproxy.py::HTTPProxyXForwardedModeTestCase::test_xforwarded_mode_with_trusted_hosts
test/test_httpproxy.py::HTTPProxyXForwardedModeTestCase::test_xforwarded_mode_with_trusted_hosts
test/test_httpproxy.py::HTTPProxyXForwardedModeTestCase::test_xforwarded_mode_without_trusted_hosts
test/test_httpproxy.py::HTTPProxyXForwardedModeTestCase::test_xforwarded_mode_without_trusted_hosts
test/test_httpproxy.py::DNSClientLoggerTestCase::test_dnsclient_assigned_logger
test/test_httpproxy.py::DNSClientLoggerTestCase::test_dnsclient_none_logger
test/test_httpproxy.py::DNSClientLoggerTestCase::test_mock_dnsclient_assigned_logger
test/test_httpproxy.py::DNSClientLoggerTestCase::test_mock_dnsclient_assigned_logger
  /Users/jakalyan/doh-proxy/dohproxy/httpproxy.py:131: DeprecationWarning: debug argument is deprecated
    app = DOHApplication(logger=logger, debug=args.debug)

test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_bad_content_type
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_request_no_content_type
test/test_httpproxy.py::HTTPProxyGETTestCase::test_get_valid_request
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_bad_dns_request
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_request_empty_body
test/test_httpproxy.py::HTTPProxyPOSTTestCase::test_post_valid_request
test/test_httpproxy.py::DNSClientLoggerTestCase::test_mock_dnsclient_assigned_logger
  /Users/jakalyan/doh-proxy/dohproxy/httpproxy.py:59: DeprecationWarning: debug property is deprecated
    dnsq = utils.dns_query_from_body(body, debug=request.app.debug)

-- Docs: https://docs.pytest.org/en/latest/warnings.html

---------- coverage: platform darwin, python 3.6.2-final-0 -----------
Name                          Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------------
dohproxy/__init__.py              1      0      0      0   100%
dohproxy/client.py               27     27      0      0     0%
dohproxy/client_protocol.py      80     12     12      4    83%
dohproxy/constants.py             5      0      0      0   100%
dohproxy/httpproxy.py            85     26     22      2    63%
dohproxy/integration.py         151    151     16      0     0%
dohproxy/proxy.py               164    164     36      0     0%
dohproxy/server_protocol.py     114     45     20      2    59%
dohproxy/stub.py                 21     21      2      0     0%
dohproxy/utils.py               120      0     18      0   100%
---------------------------------------------------------------
TOTAL                           768    446    126      8    41%
Coverage HTML written to dir htmlcov

Required test coverage of 18% reached. Total coverage: 40.94%
============================================================================================================================================================ 55 passed, 1 skipped, 26 warnings in 8.26 seconds =============================================================================================================================================================
```