### PR TITLE
Fix for hanging UDP ports

### DIFF
--- a/dohproxy/server_protocol.py
+++ b/dohproxy/server_protocol.py
@@ -145,6 +145,7 @@ class DNSClientProtocolUDP(DNSClientProtocol):
         self.transport.close()
 
     def error_received(self, exc):
+        self.transport.close()
         self.logger.exception('Error received: ' + str(exc))
 
 


### PR DESCRIPTION
Addresses https://github.com/facebookexperimental/doh-proxy/issues/66

UDP ports remain open if an exception occurs during the connection. The problem can be reproduced by setting up an upstream proxy on a port other than 52. For example:
1. `sudo PYTHONPATH=. ./dohproxy/proxy.py --upstream-resolver=::1   --certfile=./fullchain.pem   --keyfile=./privkey.pem --upstream-port=12345`
2. Send requests to it with `PYTHONPATH=. ./dohproxy/client.py --domain localhost --insecure`
3. Observe ports remaining open after every request in step 2 `netstat -ant |grep 12345`

This fix prevents this issue from happening by closing UDP ports when an exception is received.