### PR TITLE
Don't decode body twice

### DIFF
--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -60,8 +60,6 @@ async def doh1handler(request):
     except DOHDNSException as e:
         return aiohttp.web.Response(status=400, body=e.body())
 
-    dnsq = dns.message.from_wire(body)
-
     clientip = request.transport.get_extra_info('peername')[0]
     request.app.logger.info('[HTTPS] {} (Original IP: {}) {}'.format(
         clientip, request.remote, utils.dnsquery2log(dnsq)))


### PR DESCRIPTION
utils.dns_query_from_body() returns a dns.message.Message. There is no
need to decode the body twice.

Signed-off-by: Christian Heimes <cheimes@redhat.com>