### PR TITLE
Limit query size

### DIFF
--- a/dohproxy/constants.py
+++ b/dohproxy/constants.py
@@ -9,6 +9,7 @@
 
 DOH_URI = '/dns-query'
 DOH_MEDIA_TYPE = 'application/dns-message'
+DOH_MAX_QUERY_SIZE = 65535  # RFC 8484, section 6
 DOH_DNS_PARAM = 'dns'
 DOH_H2_NPN_PROTOCOLS = ['h2']
 DOH_CIPHERS = 'ECDHE+AESGCM'

--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -47,6 +47,11 @@ async def doh1handler(request):
             return aiohttp.web.Response(status=400, body=e.body())
     elif request.method == 'POST':
         body = await request.content.read()
+        # size without length indicator
+        if len(body) - 2 > constants.DOH_MAX_QUERY_SIZE:
+            return aiohttp.web.Response(
+                status=400, body=b'Size limit exceeded'
+            )
         ct = request.headers.get('content-type')
     else:
         return aiohttp.web.Response(status=501, body=b'Not Implemented')


### PR DESCRIPTION
RFC 8484 limits the size of an application/dns-message message to 65535
bytes. The limit is also implied by wire format. UDP cannot handle more
than 512 bytes well and the TCP wire format has an unsigned int 16
(ushort) size prefix.

Limit the query size early to prevent DoS with large queries.

Signed-off-by: Christian Heimes <cheimes@redhat.com>