### PR TITLE
doh-stub: Support TCP listen, multiple --listen-address (or "all")

### DIFF
--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -272,7 +272,11 @@ def main():
     logger = utils.configure_logger('doh-proxy', args.level)
     ssl_ctx = utils.create_ssl_context(args, http2=True)
     loop = asyncio.get_event_loop()
-    for addr in args.listen_address:
+    if "all" in args.listen_address:
+        listen_addresses = utils.get_system_addresses()
+    else:
+        listen_addresses = args.listen_address
+    for addr in listen_addresses:
         coro = loop.create_server(
             lambda: H2Protocol(
                 upstream_resolver=args.upstream_resolver,

--- a/dohproxy/server_protocol.py
+++ b/dohproxy/server_protocol.py
@@ -165,17 +165,9 @@ class DNSClientProtocolTCP(DNSClientProtocol):
         self.transport.write(tcpmsg)
 
     def data_received(self, data):
-        self.buffer = self.buffer + data
-        if len(self.buffer) < 2:
-            return
-        msglen = struct.unpack('!H', self.buffer[0:2])[0]
-        while msglen + 2 <= len(self.buffer):
-            dnsr = dns.message.from_wire(self.buffer[2:msglen + 2])
-            self.receive_helper(dnsr)
-            self.buffer = self.buffer[msglen + 2:]
-            if len(self.buffer) < 2:
-                return
-            msglen = struct.unpack('!H', self.buffer[0:2])[0]
+        self.buffer = utils.handle_dns_tcp_data(
+            self.buffer + data, self.receive_helper
+        )
 
     def eof_received(self):
         if len(self.buffer) > 0:


### PR DESCRIPTION
Add TCP listen support. Allow for --listen-address to be comma-separated.  Or if netifaces is installed, "all" for all detected v4/v6 addresses on all interfaces.

The DoH client is shared between all listeners (taking a little bit of work using a wrapper mutable dict).

(Sorry for the multiple force push spam.  I've got a handful of PRs inflight, and was trying to keep them as clean to merge as possible.  Originally the TCP and multiple addresses changes were separated, but I decided to combine them, as TCP itself is a separate "address" listen.)