### PR TITLE
Implement RFC 7871 EDNS Client Subnet (ECS)

### DIFF
--- a/dohproxy/httpproxy.py
+++ b/dohproxy/httpproxy.py
@@ -71,12 +71,15 @@ class DOHApplication(aiohttp.web.Application):
         self.upstream_resolver = upstream_resolver
         self.upstream_port = upstream_port
 
+    def set_ecs(self, ecs):
+        self.ecs = ecs
+
     async def resolve(self, request, dnsq):
         self.time_stamp = time.time()
         clientip = request.remote
         dnsclient = DNSClient(self.upstream_resolver, self.upstream_port,
                               logger=self.logger)
-        dnsr = await dnsclient.query(dnsq, clientip)
+        dnsr = await dnsclient.query(dnsq, clientip, ecs=self.ecs)
 
         if dnsr is None:
             return self.on_answer(request, dnsq=dnsq)
@@ -128,6 +131,7 @@ def get_app(args):
     logger = utils.configure_logger('doh-httpproxy', args.level)
     app = DOHApplication(logger=logger, debug=args.debug)
     app.set_upstream_resolver(args.upstream_resolver, args.upstream_port)
+    app.set_ecs(args.ecs)
     app.router.add_get(args.uri, doh1handler)
     app.router.add_post(args.uri, doh1handler)
 

--- a/dohproxy/proxy.py
+++ b/dohproxy/proxy.py
@@ -41,7 +41,7 @@ def parse_args():
 
 class H2Protocol(asyncio.Protocol):
     def __init__(self, upstream_resolver=None, upstream_port=None,
-                 uri=None, logger=None, debug=False):
+                 uri=None, logger=None, debug=False, ecs=False):
         config = H2Configuration(client_side=False, header_encoding='utf-8')
         self.conn = H2Connection(config=config)
         self.logger = logger
@@ -49,6 +49,7 @@ class H2Protocol(asyncio.Protocol):
             self.logger = utils.configure_logger('doh-proxy', 'DEBUG')
         self.transport = None
         self.debug = debug
+        self.ecs = ecs
         self.stream_data = {}
         self.upstream_resolver = upstream_resolver
         self.upstream_port = upstream_port
@@ -195,7 +196,7 @@ class H2Protocol(asyncio.Protocol):
         clientip = utils.get_client_ip(self.transport)
         dnsclient = DNSClient(self.upstream_resolver, self.upstream_port,
                               logger=self.logger)
-        dnsr = await dnsclient.query(dnsq, clientip)
+        dnsr = await dnsclient.query(dnsq, clientip, ecs=self.ecs)
 
         if dnsr is None:
             self.on_answer(stream_id, dnsq=dnsq)
@@ -283,7 +284,8 @@ def main():
                 upstream_port=args.upstream_port,
                 uri=args.uri,
                 logger=logger,
-                debug=args.debug),
+                debug=args.debug,
+                ecs=args.ecs),
             host=addr,
             port=args.port,
             ssl=ssl_ctx)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -529,3 +529,19 @@ class TestHandleDNSTCPData(unittest.TestCase):
         self.assertEqual(res, b'')
         self.assertIsInstance(self._cb_data[0], dns.message.Message)
         self.assertIsInstance(self._cb_data[1], dns.message.Message)
+
+
+class TestDNSECS(unittest.TestCase):
+    def test_set_dns_ecs_ipv4(self):
+        dnsq = dns.message.Message()
+        utils.set_dns_ecs(dnsq, '10.0.0.242')
+        self.assertEqual(dnsq.edns, 0)
+        self.assertEqual(dnsq.options[0].address, '10.0.0.0')
+        self.assertEqual(dnsq.options[0].srclen, 24)
+
+    def test_set_dns_ecs_ipv6(self):
+        dnsq = dns.message.Message()
+        utils.set_dns_ecs(dnsq, '2000::aa')
+        self.assertEqual(dnsq.edns, 0)
+        self.assertEqual(dnsq.options[0].address, '2000::')
+        self.assertEqual(dnsq.options[0].srclen, 56)


### PR DESCRIPTION
In a nutshell, ECS is like X-Forwarded-For for DNS, and lets DNS
resolvers and proxies tell authoritative servers where the request
originated (down to a /24 v4 or /56 v6 network).  IMHO this should
be the default, but I've left it as an option.