### PR TITLE
Explicitly define flake8 defaults

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,8 @@ test=pytest
 
 [tool:pytest]
 addopts = --verbose --cov dohproxy --cov-report html --cov-report term
+
+[flake8]
+ignore = E121,E123,E126,E226,E24,E704,W503,W504
+max-complexity = -1
+max-line-length = 79


### PR DESCRIPTION
Users with a ~/.config/flake8 may have more or less restrictive flake8
options.  Explicitly define here what we wish `setup.py flake8` to test.

(These options are flake8's defaults as of 3.7.9.)