### PR TITLE
Add TCP connect timeout

### DIFF
--- a/dohproxy/server_protocol.py
+++ b/dohproxy/server_protocol.py
@@ -85,7 +85,11 @@ class DNSClient:
                 timeout,
             )
         except asyncio.TimeoutError:
-            # Failed to connect to the resolver
+            self.logger.debug(
+                "Timeout connecting to upstream resolver {}:{}".format(
+                    self.upstream_resolver, self.upstream_port
+                )
+            )
             return None
 
         return await self._try_query(fut, qid, timeout, transport)


### PR DESCRIPTION
This fixes #99 

I repeated the same test with the exact setup as in the issue:

Server started as follows:
```
PYTHONPATH=. python3 dohproxy/httpproxy.py --trusted --upstream-resolver 192.168.2.10 --listen-address 127.0.0.1 --port 8000
```
Sample request: 

```
>curl http://127.0.0.1:8000/dns-query\?dns\=gCsBAAABAAAAAAAAB2V4YW1wbGUDY29tAAABAAE -I -w "%{time_total}" --max-time 30

HTTP/1.1 200 OK
Content-Type: application/dns-message
Content-Length: 0
Date: Thu, 11 Feb 2021 01:30:11 GMT
Server: Python/3.8 aiohttp/3.7.3

20.030092
```

Sample debug log message:
```
2021-02-10 17:25:59,159: doh-httpproxy/DEBUG: Timeout connecting to upstream resolver 192.168.2.10:53
```